### PR TITLE
Future-proofing 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "test": "ava test"
   },
   "peerDependencies": {
-    "ava": "^0.19.0",
-    "jsverify": "^0.8.2"
+    "ava": "~0.19.0",
+    "jsverify": "~0.8.2"
   },
   "devDependencies": {
-    "ava": "^0.19.0",
-    "jsverify": "^0.8.2"
+    "ava": "~0.19.0",
+    "jsverify": "~0.8.2"
   }
 }


### PR DESCRIPTION
Because pinned deps = maintenance (ie ava bugfix was released.)

And we use yarn (most of the time) which locks project deps anyhow.